### PR TITLE
1: Prevent gulp plugin from swallowing errors.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,9 @@ function gulpFlake8(opts) {
     }
     file.flake8 = {};
     var flake8 = cp.spawn('flake8', ['-']);
+    flake8.stderr.on('data', function (data) {
+      throw new Error(data.toString().trim());
+    });
     flake8.stdout.on('data', function (data) {
       file.flake8.errors = data.toString().trim().replace(
         /stdin:/g,


### PR DESCRIPTION
Currently `gulp-flake8` subscribes to `child_process`'s stdout data and not stderr.

Any exception in the child process (in this case flake8, or any of its plugins and dependencies) is not being caught, causing the plugin to fail silently (https://github.com/sophilabs/gulp-flake8/issues/1).

From this change, any error in the child process will throw an exception and stop the gulp pipeline.